### PR TITLE
Delay filtering of artifacts to allow modal to display

### DIFF
--- a/birch-artifact-selector.html
+++ b/birch-artifact-selector.html
@@ -93,13 +93,13 @@ Example:
       open='[[_open]]'
       cis-id='[[cisId]]' 
       view='[[_view]]' 
-      artifact-category='[[artifactCategory]]'
+      artifact-category='[[_artifactCategory]]'
       artifacts='{{_artifacts}}' 
       album='{{_album}}' 
       albums='{{_albums}}' 
       loading='{{loading}}'></birch-artifact-selector-data>
     <wc-i18n-src locale='[[lang]]' domain='birch-artifact-selector' locale-dir='[[localeDir()]]' locale-strings='{{_i18n}}'></wc-i18n-src>
-    <cedar-dialog id='modal' full-width on-iron-overlay-closed='_resetSelector' >
+    <cedar-dialog id='modal' full-width on-iron-overlay-closed='_resetSelector' on-iron-overlay-opened='_handleCategoryAdjust'>
       <h4 header>[[selectorTitle]]</h4>
       <div class='wrap layout horizontal justified'>
         <paper-drawer-panel id='drawer' responsive-width='979px' drawer-width='200px' edge-swipe-sensitivity='50'>
@@ -155,6 +155,17 @@ Example:
         },
         selectorTitle: {
           type: String
+        },
+
+        /**
+         * Duplicate this to allow us to handle
+         * the issue on iOS with template display
+         * @type {Object}
+         */
+        _artifactCategory: {
+          type: String,
+          value: 'any',
+          readOnly: true
         },
         artifactCategory: {
           type: String,
@@ -217,6 +228,10 @@ Example:
         } else if(this._i18n) {
           return this._i18n[view];
         }
+      },
+      _handleCategoryAdjust: function() {
+        if (this._artifactCategory === this.artifactCategory) return;
+        this._set_artifactCategory(this.artifactCategory);
       },
       _resetSelector: function() {
         this.$.grid.deselectAll();


### PR DESCRIPTION
Delays the data-binding of `artifactCategory` till the modal has had time to render. Solves a bug with iOS displaying modals slowly.